### PR TITLE
added "#define init_MUTEX(sem)  sema_init(sem, 1)" to avoid compiling error

### DIFF
--- a/README
+++ b/README
@@ -47,3 +47,18 @@ problems.
 
 
 Matthias Vallentin <vallentin@icir.org>
+
+
+//////////////////////////////////////////////////////
+Another workaround 
+/////////////////////////////////////////////////////
+
+If you know the product id and vendor id of usb serial device, then you can register it while insmod of usbserial driver.
+e.g.
+run "modprobe usbserial vendor=0x1eab product=0x0d02"
+
+You can get the product id and vendor id by using "lsusb" command.
+
+
+Gaurav Kumar <gauravkumar552@gmail.com>
+

--- a/ml_driver.c
+++ b/ml_driver.c
@@ -28,7 +28,8 @@
 #include <linux/ioctl.h>
 
 #include <asm/uaccess.h>		/* copy_*_user */
-
+#include <linux/semaphore.h>
+#define init_MUTEX(sem)         sema_init(sem, 1)// 
 /*
  * Debugging 
  */
@@ -62,8 +63,8 @@ if ((debug_level & DEBUG_LEVEL_CRITICAL) == DEBUG_LEVEL_CRITICAL) \
 /* 
  * USB Missile Launcher 
  */
-#define ML_VENDOR_ID	0x1941
-#define ML_PRODUCT_ID	0x8021
+#define ML_VENDOR_ID	0x1eab//0x1941 //idVendor           0x1eab  idProduct          0x0d02 
+#define ML_PRODUCT_ID	0x0d02//0x8021
 
 #define ML_CTRL_BUFFER_SIZE 	8
 #define ML_CTRL_REQEUST_TYPE	0x21


### PR DESCRIPTION
In makefile, LFLAGS were creating a problem,so I removed it. In ml_driver.c, init_MUTEX was unrecognized function, so I added a #define. Works fine.
